### PR TITLE
RHIN-4924: adds Kick_Admin_Hang_up message iOS

### DIFF
--- a/VoxeetUXKit/Code/ViewControllers/ConferenceViewController.swift
+++ b/VoxeetUXKit/Code/ViewControllers/ConferenceViewController.swift
@@ -694,6 +694,9 @@ extension ConferenceViewController: VTUXActionBarViewControllerDelegate {
             return
         }
 
+        // kick other participants out of conference
+        VoxeetSDK.shared.command.send(message: "Kick_Admin_Hang_up")
+
         // Leave conference (monkey patch to play sound on the same audio route).
         if let participant = VoxeetSDK.shared.session.participant {
             NotificationCenter.default.removeObserver(self, name: .VTCallKitMuteToggled, object: nil)


### PR DESCRIPTION
**Related Jira link:** https://rhinogram.atlassian.net/browse/RHIN-4914

### Fix Version
* 3.5.3

### PR Checklist
- [X] I've tested in all browsers (IE11, Firefox, Safari, Chrome, and iOS)
- [X] I have added any new environment variables to the SSM Parameter Store

### What should this PR do?
* adds Kick_Admin_Hang_up message to kick other users out of conference when member who started conference leaves
